### PR TITLE
feat: createUser mutation

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,0 +1,13 @@
+export const resolvers = {
+  Query: {
+    hello: () => 'Hello world!',
+  },
+  Mutation: {
+    createUser: (parent, args) => ({
+      id: 1,
+      name: args.input.name,
+      email: args.input.email,
+      birthDate: args.input.birthDate,
+    }),
+  },
+};

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,23 @@
+export const typeDefs = `#graphql
+type Query {
+  hello: String
+}
+
+input UserInput {
+  name: String!
+  email: String!
+  password: String!
+  birthDate: String!
+}
+
+type User {
+  id: String!
+  name: String!
+  email: String!
+  birthDate: String!
+}
+
+type Mutation {
+  createUser(input: UserInput!): User
+}
+`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,17 +1,7 @@
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
-
-const typeDefs = `#graphql
-  type Query {
-    hello: String
-  }
-`;
-
-const resolvers = {
-  Query: {
-    hello: () => 'Hello world!',
-  },
-};
+import { resolvers } from './resolver';
+import { typeDefs } from './schema';
 
 export const initializeApolloServer = async () => {
   const server = new ApolloServer({ typeDefs, resolvers });


### PR DESCRIPTION
- Mutation `createUser` (sem integração com o banco ainda)
- Separação dos resolvers e do schema em outros arquivos